### PR TITLE
Update duplicatable.rb

### DIFF
--- a/lib/active_admin/duplicatable.rb
+++ b/lib/active_admin/duplicatable.rb
@@ -46,7 +46,7 @@ module ActiveAdmin
       end
 
       controller do
-        before_filter only: :new do
+        before_action only: :new do
           if !params[:_source_id].blank?
             source = resource_class.find(params[:_source_id])
             @resource ||= source.amoeba_dup if source


### PR DESCRIPTION
before_filter has been deprecated in Rails 5.0 and removed in 5.1 using before_action