### PR TITLE
Use AA find_resource method for finding the current model

### DIFF
--- a/lib/active_admin/duplicatable.rb
+++ b/lib/active_admin/duplicatable.rb
@@ -70,8 +70,6 @@ module ActiveAdmin
       end
 
       member_action :duplicate do
-        resource  = resource_class.find(params[:id])
-
         authorize! ActiveAdmin::Auth::CREATE, resource
 
         duplicate = resource.amoeba_dup
@@ -99,8 +97,6 @@ module ActiveAdmin
       end
 
       member_action :duplicate do
-        resource = resource_class.find(params[:id])
-
         authorize! ActiveAdmin::Auth::CREATE, resource
 
         begin


### PR DESCRIPTION
- Use might have override AA find_resource for custom finder 
- Or they might use friendly_id slugged finder 

`resource_class.find` will break in both cases, plus we need to reuse existing functionality.